### PR TITLE
GJG-1 | fix: errors that 'find' writes to stderr opressed, add 'go.mo…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -82,13 +84,16 @@ func SaveConfig(path string, c *Config) error {
 func initializeConfig(cfg *Config) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Msg("failed to recognize homedir")
 	}
 
 	cmd := exec.Command("find", homeDir, "-name", "goland.sh")
 	b, err := cmd.Output()
+	if len(b) == 0 {
+		log.Fatal().Err(errors.New("find didn't find anything")).Str("search", "goland.sh").Send()
+	}
 	if err != nil {
-		log.Fatalf("failed to find goland. %s\n", err.Error())
+		log.Error().Err(err).Str("search", "goland.sh").Msg("errors finding goland.sh")
 	}
 	output := string(b)
 	paths := strings.Split(output, "\n")

--- a/internal/repos_search/repos_search.go
+++ b/internal/repos_search/repos_search.go
@@ -40,7 +40,7 @@ func detectGitRepos(path string, pathsMap map[string][]string) error {
 				fmt.Printf("failed to read dir %s\n", path)
 			}
 			for _, v := range dif {
-				if v.Name() == ".git" {
+				if v.Name() == ".git" || v.Name() == "go.mod" {
 					fp := filepath.Base(path)
 
 					if _, ok := pathsMap[fp]; !ok {

--- a/main.go
+++ b/main.go
@@ -8,11 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
 	"github.com/BUCKU/gjg/config"
 	"github.com/BUCKU/gjg/internal/consts"
 	"github.com/BUCKU/gjg/internal/repos_search"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 func main() {
@@ -50,7 +51,7 @@ func main() {
 		goSrcPath := filepath.Join(gopath, consts.GoSrcDir)
 		reposPaths, err := repos_search.CrawlPath(goSrcPath)
 		if err != nil {
-			log.Fatal().Err(err).Str("path", goSrcPath).Msg("crawling go sources")
+			log.Fatal().Err(err).Str("path", goSrcPath).Msg("crawling go sources failed.")
 		}
 
 		repoToFind := os.Args[len(os.Args)-1]
@@ -58,7 +59,7 @@ func main() {
 		var reposWithName []string
 		var ok bool
 		if reposWithName, ok = reposPaths[repoToFind]; !ok {
-			log.Fatal().Str("repo to find", repoToFind).Msg("search repo")
+			log.Fatal().Str("name", repoToFind).Msg("search repo failed. repo dir must contain either 'go.mod' or '.git' entry.")
 		}
 
 		repoOfChoice := reposPaths[repoToFind][0]


### PR DESCRIPTION
…d' to find patterns to check non-git repoes, logging